### PR TITLE
Replace Google Fonts with self-hosted fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fontsource/inter": "^4.5.1",
         "@iconscout/react-unicons": "^1.1.6",
         "@prisma/client": "^3.7.0",
         "classnames": "^2.3.1",
@@ -720,6 +721,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.1.tgz",
+      "integrity": "sha512-mvtOvXNNVLlF1p/UbLgLrmz2RCOl6Ow+TqyiK10SosoLKX7edsXYiHFHb7XIZdjII6F2sJVPPsJXWhBnbXT2DQ=="
     },
     "node_modules/@hapi/accept": {
       "version": "5.0.2",
@@ -6015,6 +6021,11 @@
           "dev": true
         }
       }
+    },
+    "@fontsource/inter": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.1.tgz",
+      "integrity": "sha512-mvtOvXNNVLlF1p/UbLgLrmz2RCOl6Ow+TqyiK10SosoLKX7edsXYiHFHb7XIZdjII6F2sJVPPsJXWhBnbXT2DQ=="
     },
     "@hapi/accept": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "seed": "node prisma/seed.js"
   },
   "dependencies": {
+    "@fontsource/inter": "^4.5.1",
     "@iconscout/react-unicons": "^1.1.6",
     "@prisma/client": "^3.7.0",
     "classnames": "^2.3.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,6 @@
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
 import "../styles/global.css";
 
 export default function MyApp({ Component, pageProps }) {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,18 +4,7 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin="anonymous"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-            rel="stylesheet"
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
Reasons to do this:
- Google Fonts don't share browser cache between sites anymore
- All the DNS resolution and handshakes have already been done
- Self-hosted fonts can be cached by service worker and work offline reliably